### PR TITLE
Fix filename in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+      - name: Copy jar file 
+        run: cp ./build/libs/license-scanner-service*.jar ./build/libs/license-scanner-service.jar
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Release get another filename, so we need to make sure the file with version does also exist.

See #9 