### PR TITLE
Add flyway commands to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'application'
     id 'com.adarshr.test-logger' version '2.1.1'
     id "org.springframework.boot" version '2.4.2'
+    id "org.flywaydb.flyway" version "7.5.2"
 }
 
 repositories {
@@ -57,5 +58,17 @@ java {
         languageVersion = JavaLanguageVersion.of(11)
     }
 }
+
+ext.ApplicationProps = new Properties()
+ApplicationProps.load(new FileInputStream("src/main/resources/application-db.properties"))
+
+flyway {
+    url = ApplicationProps['spring.datasource.url']
+    user = ApplicationProps['spring.datasource.username']
+    password = ApplicationProps['spring.datasource.password']
+}
+
+// we need to build classes before we can migrate
+flywayMigrate.dependsOn classes
 
 version = '0.4.0'


### PR DESCRIPTION
We use Flyway.
The migration files have been changed because of the changing of License.

In order to mutate the existing database we can add flyway to gradle so we have a lot of commands available on our fingertips!

---

## Flyway tasks

`flywayBaseline` - Baselines an existing database, excluding all migrations up to and including baselineVersion.
`flywayClean` - Drops all objects in the configured schemas.
`flywayInfo` - Prints the details and status information about all the migrations.
`flywayMigrate` - Migrates the schema to the latest version.
`flywayRepair` - Repairs the Flyway schema history table.
`flywayUndo` - Undoes the most recently applied versioned migration. Flyway Teams only.
`flywayValidate` - Validate applied migrations against resolved ones (on the filesystem or classpath) to detect accidental changes that may prevent the schema(s) from being recreated exactly. Validation fails if differences in migration names, types or checksums are found, versions have been applied that aren"t resolved locally anymore or versions have been resolved that haven"t been applied yet
